### PR TITLE
Fix recently found bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 project(Observer)
 
@@ -15,5 +15,10 @@ set(BUILD_API_EXAMPLES OFF CACHE INTERNAL "" FORCE)
 # Disable building of tests in the cpp-sc2 submodule.
 set(BUILD_API_TESTS OFF CACHE INTERNAL "" FORCE)
 
+# Search for Google test suite.
+find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIRS})
+
 add_subdirectory("cpp-sc2")
 add_subdirectory("src")
+add_subdirectory("test")

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ $ open Observer.xcodeproj/
 $ ./bin/Observer --Path "<Path to a single SC2 replay or directory with replay files>" --Speed <Replay speed>`
 ```
 
+## Load replays from an older SC2 versions
+To load replays from older an older SC2 version, one should additionally specify game version hash and path to the older SC2 executable, e.g. for 4.10 version:
+### Windows
+```bat
+$ bin/Observer.exe --Path "C:\Users\lladdy\Documents\358809_TyrZ_DoogieHowitzer_IceandChromeLE.SC2Replay" -- -d "B89B5D6FA7CBF6452E721311BFBC6CB2" -e "D:\Battle.net\StarCraft II\Versions\Base75689\SC2.exe"
+```
+### OS X
+```bash
+$ ./bin/Observer --Path "/Users/alkurbatov/Downloads/358809_TyrZ_DoogieHowitzer_IceandChromeLE.SC2Replay" -- -d "B89B5D6FA7CBF6452E721311BFBC6CB2" -e "/Applications/StarCraft II/Versions/Base75689/SC2.app/Contents/MacOS/SC2"
+```
+
 ## License
 Copyright (c) 2017 Daniel K�hntopp
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Starcraft 2 replays auto observer inspired by the [SSCAIT-ObserverModule](https:
   * Windows: C:\Program Files\StarCraft II\Maps
   * OS X: /Applications/StarCraft II/Maps
 
-3. Download and install [CMake](https://cmake.org/download/).
+3. Download and install [CMake >= 3.10](https://cmake.org/download/).
 
 4. A compiler with C++17 support.
+
+5. Install [Google test >= 1.10.0](https://github.com/google/googletest)
 
 5. Windows: Download and install [Visual Studio](https://www.visualstudio.com/downloads/)
 

--- a/src/ArgParser.cpp
+++ b/src/ArgParser.cpp
@@ -1,0 +1,21 @@
+#include "ArgParser.h"
+
+#include <cstring>
+
+void splitInputOptions(int argc, char* argv[], std::vector<char*>* observer_options, std::vector<char*>* sc2_options) {
+	const char* delimiter = "--";
+
+	observer_options->push_back(argv[0]);
+	sc2_options->push_back(argv[0]);
+
+	std::vector<char*>* marker = observer_options;
+
+	for (int i = 1; i < argc; ++i) {
+		if (strcmp(argv[i], delimiter) == 0) {
+			marker = sc2_options;
+			continue;
+		}
+
+		marker->push_back(argv[i]);
+	}
+}

--- a/src/ArgParser.h
+++ b/src/ArgParser.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <vector>
+
+void splitInputOptions(int argc, char* argv[], std::vector<char*>* observer_options, std::vector<char*>* sc2_options);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@ add_executable(Observer)
 
 target_sources(Observer
     PRIVATE
+        ArgParser.h
+        ArgParser.cpp
         CameraModule.h
         CameraModule.cpp
         main.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "ArgParser.h"
 #include "CameraModule.h"
 #include "Timer.hpp"
 #include "Tools.h"
@@ -9,7 +10,6 @@
 
 #include <iostream>
 #include <vector>
-
 
 class Replay : public sc2::ReplayObserver
 {
@@ -83,13 +83,17 @@ class Replay : public sc2::ReplayObserver
 
 int main(int argc, char* argv[])
 {
-	sc2::ArgParser arg_parser(argv[0]);
+	std::vector<char*> observer_options;
+	std::vector<char*> sc2_options;
+	splitInputOptions(argc, argv, &observer_options, &sc2_options);
+
+	sc2::ArgParser arg_parser(observer_options[0]);
 	arg_parser.AddOptions({
 		{ "-p", "--Path", "Path to a single SC2 replay or directory with replay files", true },
 		{ "-s", "--Speed", "Replay speed", false},
 		{ "-d", "--Delay", "Delay after game in ms.", false}
 	});
-	arg_parser.Parse(argc, argv);
+	arg_parser.Parse(static_cast<int>(observer_options.size()), &observer_options[0]);
 
 	std::string replayPath;
 	if (!arg_parser.Get("Path", replayPath))
@@ -124,7 +128,7 @@ int main(int argc, char* argv[])
 	std::vector<std::string> replayFiles;
 	unsigned long replayIndex = 0;
 	sc2::Coordinator coordinator;
-	if (!coordinator.LoadSettings(argc, argv)) {
+	if (!coordinator.LoadSettings(static_cast<int>(sc2_options.size()), &sc2_options[0])) {
 		return 1;
 	}
 	Replay replayObserver(speed, delay);

--- a/test/ArgParser.test.cpp
+++ b/test/ArgParser.test.cpp
@@ -1,0 +1,163 @@
+#include "src/ArgParser.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+TEST(splitInputOptions, ProperlySplitsObserverAndSC2Args) {
+	std::vector<char*> observer_options;
+	std::vector<char*> sc2_options;
+
+	const char* argv [] = {
+		"./bin/Observer",
+		"--Path",
+		"/Users/alkurbatov/Downloads/358809_TyrZ_DoogieHowitzer_IceandChromeLE.SC2Replay",
+		"--",
+		"-d",
+		"B89B5D6FA7CBF6452E721311BFBC6CB2",
+		"-e",
+		"/Applications/StarCraft II/Versions/Base75689/SC2.app/Contents/MacOS/SC2"
+	};
+	int argc = sizeof argv / sizeof argv[0];
+
+	splitInputOptions(argc, const_cast<char**>(argv), &observer_options, &sc2_options);
+
+	ASSERT_THAT(
+		observer_options,
+		testing::ElementsAre(
+			"./bin/Observer",
+			"--Path",
+			"/Users/alkurbatov/Downloads/358809_TyrZ_DoogieHowitzer_IceandChromeLE.SC2Replay"
+		)
+	);
+
+	ASSERT_THAT(
+		sc2_options,
+		testing::ElementsAre(
+			"./bin/Observer",
+			"-d",
+			"B89B5D6FA7CBF6452E721311BFBC6CB2",
+			"-e",
+			"/Applications/StarCraft II/Versions/Base75689/SC2.app/Contents/MacOS/SC2"
+		)
+	);
+}
+
+TEST(splitInputOptions, DoesntSplitAnythingIfDelimiterNotProvided) {
+	std::vector<char*> observer_options;
+	std::vector<char*> sc2_options;
+
+	const char* argv [] = {
+		"./bin/Observer",
+		"--Path",
+		"/Users/alkurbatov/Downloads/358809_TyrZ_DoogieHowitzer_IceandChromeLE.SC2Replay"
+	};
+	int argc = sizeof argv / sizeof argv[0];
+
+	splitInputOptions(argc, const_cast<char**>(argv), &observer_options, &sc2_options);
+
+	ASSERT_THAT(
+		observer_options,
+		testing::ElementsAre(
+			"./bin/Observer",
+			"--Path",
+			"/Users/alkurbatov/Downloads/358809_TyrZ_DoogieHowitzer_IceandChromeLE.SC2Replay"
+		)
+	);
+
+	ASSERT_THAT(
+		sc2_options,
+		testing::ElementsAre(
+			"./bin/Observer"
+		)
+	);
+}
+
+TEST(splitInputOptions, ReturnsObserverArgsIfDelimiterPassedWithoutSC2Options) {
+	std::vector<char*> observer_options;
+	std::vector<char*> sc2_options;
+
+	const char* argv [] = {
+		"./bin/Observer",
+		"--Path",
+		"/Users/alkurbatov/Downloads/358809_TyrZ_DoogieHowitzer_IceandChromeLE.SC2Replay",
+		"--"
+	};
+	int argc = sizeof argv / sizeof argv[0];
+
+	splitInputOptions(argc, const_cast<char**>(argv), &observer_options, &sc2_options);
+
+	ASSERT_THAT(
+		observer_options,
+		testing::ElementsAre(
+			"./bin/Observer",
+			"--Path",
+			"/Users/alkurbatov/Downloads/358809_TyrZ_DoogieHowitzer_IceandChromeLE.SC2Replay"
+		)
+	);
+
+	ASSERT_THAT(
+		sc2_options,
+		testing::ElementsAre(
+			"./bin/Observer"
+		)
+	);
+}
+
+TEST(splitInputOptions, ReturnsSC2ArgsIfDelimiterPassedWithoutObserverOptions) {
+	std::vector<char*> observer_options;
+	std::vector<char*> sc2_options;
+
+	const char* argv [] = {
+		"./bin/Observer",
+		"--",
+		"-d",
+		"B89B5D6FA7CBF6452E721311BFBC6CB2"
+	};
+	int argc = sizeof argv / sizeof argv[0];
+
+	splitInputOptions(argc, const_cast<char**>(argv), &observer_options, &sc2_options);
+
+	ASSERT_THAT(
+		observer_options,
+		testing::ElementsAre(
+			"./bin/Observer"
+		)
+	);
+
+	ASSERT_THAT(
+		sc2_options,
+		testing::ElementsAre(
+			"./bin/Observer",
+			"-d",
+			"B89B5D6FA7CBF6452E721311BFBC6CB2"
+		)
+	);
+}
+
+TEST(splitInputOptions, DoesntFailIfNoOptionsSpecified) {
+	std::vector<char*> observer_options;
+	std::vector<char*> sc2_options;
+
+	const char* argv [] = {
+		"./bin/Observer"
+	};
+	int argc = sizeof argv / sizeof argv[0];
+
+	splitInputOptions(argc, const_cast<char**>(argv), &observer_options, &sc2_options);
+
+	ASSERT_THAT(
+		observer_options,
+		testing::ElementsAre(
+			"./bin/Observer"
+		)
+	);
+
+	ASSERT_THAT(
+		sc2_options,
+		testing::ElementsAre(
+			"./bin/Observer"
+		)
+	);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,11 @@
+include(GoogleTest)
+
+include_directories(${PROJECT_SOURCE_DIR})
+
+add_executable(
+    TestArgParser
+    ${PROJECT_SOURCE_DIR}/src/ArgParser.h
+    ${PROJECT_SOURCE_DIR}/src/ArgParser.cpp
+    ArgParser.test.cpp)
+target_link_libraries(TestArgParser GTest::Main)
+gtest_discover_tests(TestArgParser)


### PR DESCRIPTION
* Document how to launch old replays (OS X + Win).
* Split the input params with '--'. The observer's params go before '--', the game params go after '--'.
* Rebase on the newer API: Abort the game launch if we found an unexpected option.
* Integrate Google tests.